### PR TITLE
Remove logger and fix serverAddr

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,24 +5,25 @@ import (
 	"crispy-journey/server"
 	"log"
 	"net/http"
-	"os"
 )
 
-const serverAddr = "localhost:8080"
+const serverAddr = ":8080"
 
 func main() {
-	logger := log.New(os.Stdout, "[CRISPY-JOURNEY] ", log.Ltime|log.Lshortfile)
+	log.SetPrefix("[CRISPY-JOURNEY] ")
+	log.SetFlags(log.Ltime)
 
-	// Set up the router
-	router := router.NewRouter(logger)
+	// Use custom "router" package to have all the routes in the same file
+	router := router.NewRouter()
 	mux := http.NewServeMux()
 	router.AddRoutes(mux)
 
+	// Use custom "server" package to configure http.Server with TLS
 	s := server.New(mux, serverAddr)
 
-	logger.Printf("Server starting on %s\n", serverAddr)
+	log.Printf("Server starting on %s\n", serverAddr)
 	err := s.ListenAndServe()
 	if err != nil {
-		logger.Fatalf("Server failed to start: %v", err)
+		log.Fatalf("Server failed to start: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -3,10 +3,8 @@ package main
 import (
 	"crispy-journey/router"
 	"crispy-journey/server"
-	"log"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/matryer/is"
@@ -14,32 +12,30 @@ import (
 
 func TestStackHome(t *testing.T) {
 	is := is.New(t)
-	logger := log.New(os.Stdout, "[TESTING] ", log.Ltime|log.Lshortfile)
 
-	// Set up the server
-	router := router.NewRouter(logger)
+	// Use custom "router" package to have all the routes in the same file
+	router := router.NewRouter()
 	mux := http.NewServeMux()
 	router.AddRoutes(mux)
+
+	// Use custom "server" package to configure http.Server with TLS
 	s := server.New(mux, serverAddr)
 
-	// Create and send the request
 	r := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w, r)
 
-	is.Equal(w.Code, http.StatusOK) // Expect status code 200
+	is.Equal(w.Code, http.StatusOK) // Expect status code 200 (OK)
 }
 
 func TestHandleHome(t *testing.T) {
 	is := is.New(t)
 
-	// Set up the server
-	router := router.NewRouter(nil)
+	router := router.NewRouter()
 
-	// Create and send the request
 	r := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	router.HandleHome(w, r)
 
-	is.Equal(w.Code, http.StatusOK) // Expect status code 200
+	is.Equal(w.Code, http.StatusOK) // Expect status code 200 (OK)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -2,38 +2,23 @@
 package router
 
 import (
-	"log"
 	"net/http"
-	"time"
 )
 
-// Router represents a router with embedded logger
-type Router struct {
-	logger *log.Logger
-}
+// Router represents a router with all its routes and associated handlers
+type Router struct{}
 
-// NewRouter creates a variable of Router type with embedded logger
-func NewRouter(logger *log.Logger) *Router {
-	return &Router{
-		logger: logger,
-	}
+// NewRouter creates a variable of Router type for external access to the below methods
+func NewRouter() *Router {
+	return &Router{}
 }
 
 // AddRoutes adds a handler for all the routes of the server
 func (router *Router) AddRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/", router.Logger(router.HandleHome))
+	mux.HandleFunc("/", router.HandleHome)
 }
 
-// Logger wraps all the handlers to add some logging
-func (router *Router) Logger(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		startTime := time.Now()
-		defer router.logger.Printf("Request processed in %s\n", time.Now().Sub(startTime))
-		next(w, r)
-	}
-}
-
-// HandleHome handles home page at path /
+// HandleHome handles path "/"
 func (router *Router) HandleHome(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- Remove the logger embedded in router package and associated middleware (we ain't want no loggin')
- Switch `serverAddr` from `localhost:8080` to `:8080`, which seemed to cause issues when running the Docker container